### PR TITLE
Redactor.php - Prevent overriding default clientOptions

### DIFF
--- a/widgets/Redactor.php
+++ b/widgets/Redactor.php
@@ -31,6 +31,14 @@ class Redactor extends InputWidget
     ];
     private $_assetBundle;
 
+	public function __construct($options = [])
+	{
+		if (isset($options['clientOptions'])) {
+			$options['clientOptions'] = array_merge($this->clientOptions, $options['clientOptions']);
+		}
+		parent::__construct($options);
+	}
+
     public function init()
     {
         if (!isset($this->options['id'])) {


### PR DESCRIPTION
Prevent overriding default clientOptions by using widget when user does not specify it.
Without this instruction user have to define imageManagerJson, imageUpload, fileUpload manually every time when use widget.