### PR TITLE
[BugFix] Lang param should be passed to script

### DIFF
--- a/widgets/Redactor.php
+++ b/widgets/Redactor.php
@@ -88,6 +88,7 @@ class Redactor extends InputWidget
         $langAsset = 'lang/' . $this->clientOptions['lang'] . '.js';
         if (file_exists($this->sourcePath . DIRECTORY_SEPARATOR . $langAsset)) {
             $this->assetBundle->js[] = $langAsset;
+            $this->clientOptions['lang'] = $lang;
         } else {
             ArrayHelper::remove($this->clientOptions, 'lang');
         }


### PR DESCRIPTION
If ArrayHelper::getValue return default value, it will not be passed to redactor JS by clientOptions. In fact redactor will use embedded language (it means English).
This commit fix this bug.